### PR TITLE
If a given page/blog post has a summary/title/author, use that instead of the site-wide ones

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -49,12 +49,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
     <!--meta name="author" content="Mohan Balachandran">
         <meta name="robots" content="noindex, nofollow"-->
-    <meta name="description" content="{{ $.Site.Params.description }}" />
-    <meta name="author" content="{{ $.Site.Params.author }}" />
+    <meta name="description" content="{{ .Params.Summary | default $.Site.Params.description }}" />
+    <meta name="author" content="{{ .Params.authorname | default $.Site.Params.author }}" />
     <meta name="robots" content="{{ $.Site.Params.robots }}" />
   <base
       href="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}">
-  <title>{{ $.Site.Title }}</title>
+  {{ with .Param "Title" }}
+    <title>{{ . }} - {{ $.Site.Title }}</title>
+  {{ else }}
+    <title>{{ $.Site.Title }}</title>
+  {{ end }}
 
   {{ $stylesheet := .Site.Data.webpack.main }}
   {{ with $stylesheet.css }}


### PR DESCRIPTION
Previews on Slack etc. do not contain the page-specific stuff. I think they should:
![image](https://user-images.githubusercontent.com/591435/122601186-ea286e00-d03e-11eb-8bb0-efbb3b4dcc8b.png)

Titles become e.g. `<title>Grafana and Prometheus - Penn Way to Health</title>` if there's one present, or remain as `<title>Penn Way to Health</title>` otherwise (e.g. on the blog list page.

For meta tags, the page's summary and/or authorname replace the site-wide description and author if present.